### PR TITLE
chore: sync versioned flow from cluster - 1.16.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,8 @@ jobs:
           version: 20.10.14
       - checkout
       - run: mvn clean install -DskipTests
-      - run: mkdir ./nifi-docker/dockerhub/nifi/ && cp ./nifi-assembly/target/nifi-?.??.?-bin.zip ./nifi-docker/dockerhub/nifi/
+      # TODO: handle "-SNAPSHOT" in binary name. Need to pass it as a build arg to dockerfile
+      - run: mkdir ./nifi-docker/dockerhub/nifi/ && cp ./nifi-assembly/target/nifi-?.??.*-bin.zip ./nifi-docker/dockerhub/nifi/
       - run: cd nifi-docker/dockerhub && docker build --build-arg NIFI_BINARY_PATH=nifi -t quay.io/influxdb/nifi:${CIRCLE_SHA1} .
       - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
       - run: docker push quay.io/influxdb/nifi:${CIRCLE_SHA1}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2.0
+
+jobs:
+  build:
+    docker:
+      - image: cimg/openjdk:8.0.322
+    steps:
+      - setup_remote_docker:
+          version: 20.10.14
+      - checkout
+      - run: mvn clean install -DskipTests
+      - run: mkdir ./nifi-docker/dockerhub/nifi/ && cp ./nifi-assembly/target/nifi-?.??.?-bin.zip ./nifi-docker/dockerhub/nifi/
+      - run: cd nifi-docker/dockerhub && docker build --build-arg NIFI_BINARY_PATH=nifi -t quay.io/influxdb/nifi:${CIRCLE_SHA1} .
+      - run: docker login -u=$QUAY_USER -p=$QUAY_PASS quay.io
+      - run: docker push quay.io/influxdb/nifi:${CIRCLE_SHA1}
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build
+    

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - setup_remote_docker:
           version: 20.10.14
       - checkout
-      - run: mvn clean install -DskipTests
+      - run: mvn -T 2.0C clean install -DskipTests
       # TODO: handle "-SNAPSHOT" in binary name. Need to pass it as a build arg to dockerfile
       - run: mkdir ./nifi-docker/dockerhub/nifi/ && cp ./nifi-assembly/target/nifi-?.??.*-bin.zip ./nifi-docker/dockerhub/nifi/
       - run: cd nifi-docker/dockerhub && docker build --build-arg NIFI_BINARY_PATH=nifi -t quay.io/influxdb/nifi:${CIRCLE_SHA1} .

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 name: ci-workflow
 
-on: [push, pull_request]
+# on: [push, pull_request]
 
 env:
   DEFAULT_MAVEN_OPTS: >-

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,10 +15,10 @@
 # limitations under the License.
 name: Manage stale PRs
 
-on:
-  # Run every day at midnight 00:00
-  schedule:
-    - cron: "0 0 * * *"
+# on:
+#   # Run every day at midnight 00:00
+#   schedule:
+#     - cron: "0 0 * * *"
 
 jobs:
   stale:

--- a/.github/workflows/system-tests.yml
+++ b/.github/workflows/system-tests.yml
@@ -15,10 +15,16 @@
 # limitations under the License.
 name: system-tests
 
-on:
-  # Run every day at 00:00
-  schedule:
-    - cron: "0 0 * * *"
+# on:
+#   # Run every day at 00:00
+#   schedule:
+#     - cron: "0 0 * * *"
+#   push:
+#     paths:
+#       - 'nifi-system-tests/**'
+#   pull_request:
+#     paths:
+#       - 'nifi-system-tests/**'
 
 env:
   DEFAULT_MAVEN_OPTS: >-

--- a/nifi-docker/dockerhub/Dockerfile
+++ b/nifi-docker/dockerhub/Dockerfile
@@ -60,9 +60,10 @@ RUN curl -fSL ${MIRROR_BASE_URL}/${NIFI_TOOLKIT_BINARY_PATH} -o ${NIFI_BASE_DIR}
     && ln -s ${NIFI_TOOLKIT_HOME} ${NIFI_BASE_DIR}/nifi-toolkit-${NIFI_VERSION}
 
 # Download, validate, and expand Apache NiFi binary.
-RUN curl -fSL ${MIRROR_BASE_URL}/${NIFI_BINARY_PATH} -o ${NIFI_BASE_DIR}/nifi-${NIFI_VERSION}-bin.zip \
-    && echo "$(curl ${BASE_URL}/${NIFI_BINARY_PATH}.sha256) *${NIFI_BASE_DIR}/nifi-${NIFI_VERSION}-bin.zip" | sha256sum -c - \
-    && unzip ${NIFI_BASE_DIR}/nifi-${NIFI_VERSION}-bin.zip -d ${NIFI_BASE_DIR} \
+ADD ${NIFI_BINARY_PATH}/nifi-${NIFI_VERSION}-bin.zip ${NIFI_BASE_DIR}/nifi-${NIFI_VERSION}-bin.zip
+# RUN curl -fSL ${MIRROR_BASE_URL}/${NIFI_BINARY_PATH} -o ${NIFI_BASE_DIR}/nifi-${NIFI_VERSION}-bin.zip \
+# && echo "$(curl ${BASE_URL}/${NIFI_BINARY_PATH}.sha256) *${NIFI_BASE_DIR}/nifi-${NIFI_VERSION}-bin.zip" | sha256sum -c - \
+RUN unzip ${NIFI_BASE_DIR}/nifi-${NIFI_VERSION}-bin.zip -d ${NIFI_BASE_DIR} \
     && rm ${NIFI_BASE_DIR}/nifi-${NIFI_VERSION}-bin.zip \
     && mv ${NIFI_BASE_DIR}/nifi-${NIFI_VERSION} ${NIFI_HOME} \
     && mkdir -p ${NIFI_HOME}/conf \

--- a/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
+++ b/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-framework-core/src/main/java/org/apache/nifi/controller/StandardFlowService.java
@@ -1023,7 +1023,7 @@ public class StandardFlowService implements FlowService, ProtocolHandler {
             controller.setNodeId(nodeId);
 
             // load new controller state
-            loadFromBytes(dataFlow, true, BundleUpdateStrategy.USE_SPECIFIED_OR_FAIL);
+            loadFromBytes(dataFlow, true, BundleUpdateStrategy.USE_SPECIFIED_OR_COMPATIBLE_OR_GHOST);
 
             // set node ID on controller before we start heartbeating because heartbeat needs node ID
             clusterCoordinator.setLocalNodeIdentifier(nodeId);


### PR DESCRIPTION
Same as https://github.com/influxdata/nifi/pull/1 but from 1.16.0 instead of 1.16.1