### PR TITLE
chore(nifi): bump jettison dep to 1.5.1

### DIFF
--- a/nifi-nar-bundles/nifi-framework-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-framework-bundle/pom.xml
@@ -284,7 +284,7 @@
             <dependency>
                 <groupId>org.codehaus.jettison</groupId>
                 <artifactId>jettison</artifactId>
-                <version>1.3.7</version>
+                <version>1.5.1</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.security</groupId>

--- a/nifi-nar-bundles/nifi-spark-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-spark-bundle/pom.xml
@@ -46,7 +46,7 @@
             <dependency>
                 <groupId>org.codehaus.jettison</groupId>
                 <artifactId>jettison</artifactId>
-                <version>1.3.8</version>
+                <version>1.5.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-configuration</groupId>

--- a/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/nifi-registry-ranger-plugin/pom.xml
+++ b/nifi-registry/nifi-registry-extensions/nifi-registry-ranger/nifi-registry-ranger-plugin/pom.xml
@@ -279,7 +279,7 @@
         <dependency>
             <groupId>org.codehaus.jettison</groupId>
             <artifactId>jettison</artifactId>
-            <version>1.3.8</version>
+            <version>1.5.1</version>
         </dependency>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
Helps https://github.com/influxdata/data-acquisition/issues/514

Bumps jettison to 1.5.1 to resolve cve https://github.com/influxdata/dependabot-for-nifi-influxdata/security/dependabot/41

I chose 1.5.1 because that's what is proposed in the Apache issue for resolving this CVE upstream: https://issues.apache.org/jira/browse/NIFI-10609